### PR TITLE
Fix scraping the rappels and vehicles

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -46,6 +46,7 @@ async function parseRoute(url: string): Promise<any> {
     const qualityPopSection = tableElementRowMap['Rating']!;
     const quality = qualityPopSection.querySelectorAll('.starRate4')?.length ?? 0 + (qualityPopSection.querySelectorAll('.starRate2')?.length ?? 0) / 2;
     const months = parseMonths(tableElementRowMap['Best season'])
+    const vehicle = tableElementRowMap['Vehicle']?.textContent?.trim().replace("Vehicle:", '')
 
     // Typically we just need the last element
     var tableElements = {};
@@ -53,7 +54,7 @@ async function parseRoute(url: string): Promise<any> {
         tableElements[key] = mostReleventElement(key, tableElementRowMap[key]);
     }
     const rating = tableElements['Difficulty']?.textContent.trim() ?? "";            
-
+    
     // popularity is currently broken
     const popularity =  tableElements['StarRank'] && parseInt(tableElements['StarRank'].querySelector('.starRate > span')!.textContent!.slice(2));
     return {
@@ -66,7 +67,7 @@ async function parseRoute(url: string): Promise<any> {
         Months: months,
         Difficulty: parseDifficulty(rating),
         AdditionalRisk: parseAdditionalRisk(rating),
-        Vehicle: tableElements['Vehicle']?.textContent.trim(),
+        Vehicle: vehicle,
         Shuttle: tableElements['Shuttle']?.textContent.trim(),
         Permits: tableElements['Red Tape']?.textContent.trim(),
         Sports: parseSport(rating, ['canyoneering']),

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,9 @@ import parseMonths from './utils/parseMonths';
 let first = true;
 async function main() {
     console.log('[');
-    await Promise.all((await getRouteURLs()).map(async url => {
+    
+    const urls = await getRouteURLs()
+    await Promise.all((urls).map(async url => {
         try {
             const route = await parseRoute(url);
             if (first) { first = false; } else { console.log(','); }

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,7 @@ import parseAdditionalRisk  from './utils/parseAdditionalRisk';
 import {parseDescription} from './utils/parseDescription';
 import {parseRaps} from './utils/parseRaps';
 import parseKML from './utils/parseKML';
-import {parseTable} from './utils/parseTable';
+import {parseTable, mostReleventElement} from './utils/parseTable';
 import parseMonths from './utils/parseMonths';
 
 let first = true;
@@ -36,17 +36,24 @@ async function parseRoute(url: string): Promise<any> {
     const text = await cachedFetch(url);
     const {window: {document}} = new jsdom.JSDOM(text, {url});
 
-    const tableElements = parseTable(document.querySelector('.tablecanyon tbody'));
-    const rating = tableElements['Difficulty']?.textContent.trim() ?? "";
-    const raps = parseRaps(tableElements['Raps']?.textContent.trim());
+    // This generally works but not for linked bluugnome data
     const kml = await parseKML(document);
 
-    const qualityPopSection = tableElements['Rating']!;
+    const tableElementRowMap = parseTable(document.querySelector('.tablecanyon tbody'));
+    const raps = parseRaps(tableElementRowMap['Raps']);
+    const qualityPopSection = tableElementRowMap['Rating']!;
     const quality = qualityPopSection.querySelectorAll('.starRate4')?.length ?? 0 + (qualityPopSection.querySelectorAll('.starRate2')?.length ?? 0) / 2;
+    const months = parseMonths(tableElementRowMap['Best season'])
+
+    // Typically we just need the last element
+    var tableElements = {};
+    for (let key in tableElementRowMap) {
+        tableElements[key] = mostReleventElement(key, tableElementRowMap[key]);
+    }
+    const rating = tableElements['Difficulty']?.textContent.trim() ?? "";            
 
     // popularity is currently broken
     const popularity =  tableElements['StarRank'] && parseInt(tableElements['StarRank'].querySelector('.starRate > span')!.textContent!.slice(2));
-
     return {
         URL: url,
         Name: document.querySelector('h1')!.textContent!,
@@ -54,7 +61,7 @@ async function parseRoute(url: string): Promise<any> {
         Popularity: popularity,
         Latitude: tableElements['Location'] && parseFloat(tableElements['Location'].textContent!.split(',')[0]),
         Longitude: tableElements['Location'] && parseFloat(tableElements['Location'].textContent!.split(',')[1]),
-        Months: parseMonths(tableElements),
+        Months: months,
         Difficulty: parseDifficulty(rating),
         AdditionalRisk: parseAdditionalRisk(rating),
         Vehicle: tableElements['Vehicle']?.textContent.trim(),

--- a/src/utils/parseMonths.ts
+++ b/src/utils/parseMonths.ts
@@ -16,7 +16,7 @@ export type Month = (
     'December');
 
 
-const months: Month[] = [
+const monthLookup: Month[] = [
     'January',
     'Feburary',
     'March',
@@ -31,6 +31,6 @@ const months: Month[] = [
     'December'
 ];
 
-export default function parseMonths(tableElements: any): Month[] {
-    return _.compact(tableElements['Best season'] && toArray(tableElements['Best season'].querySelectorAll('.wikitable.bst td:not(.bss)')).map((el, index) => (el.className === 'bsg' ? months[index] : undefined)));
+export default function parseMonths(months: Element): Month[] {
+    return _.compact(toArray(months.querySelectorAll('.wikitable.bst td:not(.bss)')).map((el, index) => (el.className === 'bsg' ? monthLookup[index] : undefined)));
 }

--- a/src/utils/parseRaps.ts
+++ b/src/utils/parseRaps.ts
@@ -1,6 +1,8 @@
-export function parseRaps(value: string): {countMin?: number; countMax?: number; lengthMax?: number} {
-    const maxMatch = value?.match(/Max ↕([0-9]+ft$)/i);
-    const countMatch = value?.match(/^([0-9]+)(-([0-9]+))?/);
+import _, {toArray} from 'lodash';
+
+export function parseRaps(row: Element): {countMin?: number; countMax?: number; lengthMax?: number} {
+    const maxMatch = row.textContent?.match(/max ↨([0-9]+)ft/i);
+    const countMatch = row.textContent?.match(/Raps\: ([0-9]+)(-([0-9]+))?/);
 
     return {
         countMin: parseInt(countMatch?.[1] || '', 10),

--- a/src/utils/parseRaps.ts
+++ b/src/utils/parseRaps.ts
@@ -2,7 +2,8 @@ import _, {toArray} from 'lodash';
 
 export function parseRaps(row: Element): {countMin?: number; countMax?: number; lengthMax?: number} {
     const maxMatch = row.textContent?.match(/max ↨([0-9]+)ft/i);
-    const countMatch = row.textContent?.match(/Raps\: ([0-9]+)(-([0-9]+))?/);
+    // The random period is because sometimes its a space and sometimes its some random blank character (maybe a tab?)
+    const countMatch = row.textContent?.match(/Raps\:.([0-9]+)(-([0-9]+))?/);
 
     return {
         countMin: parseInt(countMatch?.[1] || '', 10),

--- a/src/utils/parseTable.ts
+++ b/src/utils/parseTable.ts
@@ -1,26 +1,34 @@
 import _, {toArray} from 'lodash';
 
-export function parseTable(tableEl: Element | null | undefined): any {
+export function parseTable(tableEl: Element | null | undefined): { [id: string]: Element; } {
     if (!tableEl) return {};
 
-    const one = _.fromPairs(toArray(tableEl!.children).map(tr => {
-        const th = tr.querySelector('th');
-        if (!th) { return []; } else { return [th.textContent?.slice(0, th.textContent.length - 1), tr.querySelector('td')]; }
-    }));
+    var tableRowMap = {};
+    toArray(tableEl.children).forEach(function (row) { 
+        const headerText = row.querySelector('th')?.textContent;        
+        if (headerText) { 
+            const rowName = headerText!.slice(0, headerText!.length - 1)
+            tableRowMap[rowName] = row
+        } 
+    })
 
-    const two = _.fromPairs(toArray(tableEl.querySelectorAll('div.detailsRow')).map(tr => {
-        const th = tr.querySelector('.detailsRowDescriptor');        
-        if (!th) { 
-            return []; 
-        } else { 
-            // permits has a <u> instead of a <span>
-            var found = _.last(tr.querySelectorAll('u'))
-            if (found == null) {
-                found = _.last(tr.querySelectorAll('span'))
-            }
-            return [th.textContent?.slice(0, th.textContent.length - 1), found]; 
-        }
-    }));
+    tableEl.querySelectorAll('div.detailsRow').forEach(function (row) { 
+        const headerText = row.querySelector('.detailsRowDescriptor')?.textContent;        
+        if (headerText) { 
+            const rowName = headerText!.slice(0, headerText!.length - 1)
+            tableRowMap[rowName] = row
+        } 
+    })
+    return tableRowMap
+}
 
-    return {...one, ...two};
+// Different rows have different DOM makeup
+export function mostReleventElement(key: string, row: Element): Element | null | undefined {
+    if (key == "Overall" || key == "Location" || key == "Best season") {
+        return row.querySelector('td')
+    } else if (key == "Red Tape") {
+        return _.last(row.querySelectorAll('u'))
+    } else {
+        return _.last(row.querySelectorAll('span'))
+    }
 }


### PR DESCRIPTION
The forcing function of the tabling change is that it is now we need the parent row object for vehicles and rapels and the table dictionary created only supported a leaf. So I had to make decent changes which I attended to add more self documenting naming and typing during.