### PR TITLE
Add missing KML end tag when needed

### DIFF
--- a/src/scrape/scrapeKMLs.ts
+++ b/src/scrape/scrapeKMLs.ts
@@ -53,7 +53,12 @@ export async function scrapeKMLs(
       const url = new URL('https://ropewiki.com/luca/rwr');
       url.searchParams.append('gpx', 'off');
 
-      const text = await cachedFetch(new URL(`${url.toString()}&kml=${url1.toString()}`));
+      let text = await cachedFetch(new URL(`${url.toString()}&kml=${url1.toString()}`));
+
+      // Sometimes the document is missing a KML end tag. This hack seems to always fix it.
+      if (!text.trim().endsWith('</kml>')) {
+        text += '</kml>';
+      }
 
       const document = new xmldom.DOMParser().parseFromString(text);
       const els = Array.from(document.getElementsByTagName('Document'));

--- a/src/scrape/scrapeKMLs.ts
+++ b/src/scrape/scrapeKMLs.ts
@@ -7,7 +7,11 @@ import {logger} from '../logger';
 import cachedFetch from './cachedFetch';
 import {validate} from './getValidator';
 
-const limit = 100;
+/**
+ * The maximum number of KMLs to load per batched request.
+ * A larger number results in fewer requests but each request is slower and more expensive.
+ */
+const kmlCountPerRequest = 10;
 
 /**
  * Take an array of `RouteV2`s and a list of their RopeWiki regions, scrape their KMLs,
@@ -25,7 +29,7 @@ export async function scrapeKMLs(
     while (true) {
       const url1 = new URL(`http://ropewiki.com/index.php/KMLList`);
       url1.searchParams.append('offset', `${offset}`);
-      url1.searchParams.append('limit', `${limit}`);
+      url1.searchParams.append('limit', `${kmlCountPerRequest}`);
       url1.searchParams.append('action', `raw`);
       url1.searchParams.append('templates', `expand`);
       url1.searchParams.append('ctype', `application/x-zope-edit`);


### PR DESCRIPTION
@17jmumford originally saw these KML parsing errors in his python scraper. I found that adding a closing `</kml>` tag if one is not present fixes the errors. The files are otherwise valid.

Also in this PR is a calibration of the # of KMLs we request per batch. I found 10 worked nicely. 