### PR TITLE
Fix rappel parsing issue and restore ability to run yarn

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,14 @@ Install native dependencies
 - [tippecanoe](https://github.com/mapbox/tippecanoe) (>= v1.36)
 - [mapnik](https://github.com/mapbox/tippecanoe) (>= v1.36)
 
+One recommendation to install these is using [brew](https://brew.sh)
+```
+brew install yarn
+brew install pandoc
+brew install tippecanoe
+brew install mapnik
+```
+
 Clone this git repository
 
 ```
@@ -73,6 +81,12 @@ AWS Access Key ID [None]: {COPY FROM PREVIOUS STEP}
 AWS Secret Access Key [None]: {COPY FROM PREVIOUS STEP}
 Default region name [None]:
 Default output format [None]:
+```
+
+Run the tests
+
+```
+yarn test
 ```
 
 Run the scraper

--- a/fixtures/cache/39299b9159aae0e70e92e3e560a57c3f.txt
+++ b/fixtures/cache/39299b9159aae0e70e92e3e560a57c3f.txt
@@ -1,418 +1,418 @@
 {
-"printrequests": [
-{
-"label": "",
-"typeid": "_wpg",
-"mode": 2,
-"format": false
-},
-{
-"label": "pageid",
-"typeid": "_txt",
-"mode": 1,
-"format": ""
-},
-{
-"label": "name",
-"typeid": "_txt",
-"mode": 1,
-"format": ""
-},
-{
-"label": "coordinates",
-"typeid": "_geo",
-"mode": 1,
-"format": ""
-},
-{
-"label": "region",
-"typeid": "_wpg",
-"mode": 1,
-"format": ""
-},
-{
-"label": "quality",
-"typeid": "_num",
-"mode": 1,
-"format": ""
-},
-{
-"label": "rating",
-"typeid": "_txt",
-"mode": 1,
-"format": ""
-},
-{
-"label": "timeRating",
-"typeid": "_txt",
-"mode": 1,
-"format": ""
-},
-{
-"label": "kmlUrl",
-"typeid": "_txt",
-"mode": 1,
-"format": ""
-},
-{
-"label": "technicalRating",
-"typeid": "_txt",
-"mode": 1,
-"format": ""
-},
-{
-"label": "waterRating",
-"typeid": "_txt",
-"mode": 1,
-"format": ""
-},
-{
-"label": "riskRating",
-"typeid": "_txt",
-"mode": 1,
-"format": ""
-},
-{
-"label": "permits",
-"typeid": "_txt",
-"mode": 1,
-"format": ""
-},
-{
-"label": "rappelCount",
-"typeid": "_txt",
-"mode": 1,
-"format": ""
-},
-{
-"label": "rappelLongest",
-"typeid": "_qty",
-"mode": 1,
-"format": ""
-},
-{
-"label": "months",
-"typeid": "_txt",
-"mode": 1,
-"format": ""
-},
-{
-"label": "shuttle",
-"typeid": "_qty",
-"mode": 1,
-"format": ""
-},
-{
-"label": "vehicle",
-"typeid": "_txt",
-"mode": 1,
-"format": ""
-}
-],
-"results": {
-"Bickford Slides Canyon": {
-"printouts": {
-"pageid": [
-"68720"
-],
-"name": [
-"Bickford Slides Canyon"
-],
-"coordinates": [
-{
-"lat": 44.274,
-"lon": -70.9843
-}
-],
-"region": [
-{
-"fulltext": "Maine",
-"fullurl": "https://ropewiki.com/Maine",
-"namespace": 0,
-"exists": true
-}
-],
-"quality": [
-3
-],
-"rating": [
-" 3C II  (\u003Ci\u003Ev3a4\u0026nbsp;II\u003C/i\u003E)"
-],
-"timeRating": [
-"II"
-],
-"kmlUrl": [],
-"technicalRating": [
-"3"
-],
-"waterRating": [
-"C"
-],
-"riskRating": [],
-"permits": [
-"No"
-],
-"rappelCount": [
-"3r"
-],
-"rappelLongest": [
-{
-"value": 50,
-"unit": "ft"
-}
-],
-"months": [
-"Jun",
-"Jul",
-"Aug",
-"Sep",
-"Oct"
-],
-"shuttle": [],
-"vehicle": []
-},
-"fulltext": "Bickford Slides Canyon",
-"fullurl": "https://ropewiki.com/Bickford_Slides_Canyon",
-"namespace": 0,
-"exists": true
-},
-"Inman's Cave": {
-"printouts": {
-"pageid": [
-"68718"
-],
-"name": [
-"Inman's Cave"
-],
-"coordinates": [
-{
-"lat": 44.2165,
-"lon": -69.0747
-}
-],
-"region": [
-{
-"fulltext": "Maine",
-"fullurl": "https://ropewiki.com/Maine",
-"namespace": 0,
-"exists": true
-}
-],
-"quality": [
-0
-],
-"rating": [
-"Cave 3A I  (\u003Ci\u003Ev2a1\u0026nbsp;I\u003C/i\u003E)"
-],
-"timeRating": [
-"I"
-],
-"kmlUrl": [],
-"technicalRating": [
-"3"
-],
-"waterRating": [
-"A"
-],
-"riskRating": [],
-"permits": [
-"No"
-],
-"rappelCount": [
-"2r"
-],
-"rappelLongest": [
-{
-"value": 20,
-"unit": "ft"
-}
-],
-"months": [],
-"shuttle": [],
-"vehicle": []
-},
-"fulltext": "Inman's Cave",
-"fullurl": "https://ropewiki.com/Inman%27s_Cave",
-"namespace": 0,
-"exists": true
-},
-"Mount Katahdin": {
-"printouts": {
-"pageid": [
-"25753"
-],
-"name": [
-"Mount Katahdin"
-],
-"coordinates": [
-{
-"lat": 45.9043,
-"lon": -68.922
-}
-],
-"region": [
-{
-"fulltext": "Maine",
-"fullurl": "https://ropewiki.com/Maine",
-"namespace": 0,
-"exists": true
-}
-],
-"quality": [
-5
-],
-"rating": [
-"POI"
-],
-"timeRating": [],
-"kmlUrl": [
-"https://ropewiki.com/luca/rwr?gpx%3Doff\u0026filename%3DMount_Katahdin\u0026kmlnfx\u0026kmlx%3Dhttp://brennen.caltech.edu/swhikes/katadn.htm\u0026ext%3D.kml"
-],
-"technicalRating": [],
-"waterRating": [],
-"riskRating": [],
-"permits": [
-"No"
-],
-"rappelCount": [],
-"rappelLongest": [],
-"months": [],
-"shuttle": [],
-"vehicle": []
-},
-"fulltext": "Mount Katahdin",
-"fullurl": "https://ropewiki.com/Mount_Katahdin",
-"namespace": 0,
-"exists": true
-},
-"Screw Auger Falls Gorge": {
-"printouts": {
-"pageid": [
-"34280"
-],
-"name": [
-"Screw Auger Falls Gorge"
-],
-"coordinates": [
-{
-"lat": 44.571944444444,
-"lon": -70.91
-}
-],
-"region": [
-{
-"fulltext": "Maine",
-"fullurl": "https://ropewiki.com/Maine",
-"namespace": 0,
-"exists": true
-}
-],
-"quality": [
-0
-],
-"rating": [
-" 3C1 I  (\u003Ci\u003Ev2a4\u0026nbsp;I\u003C/i\u003E)"
-],
-"timeRating": [
-"I"
-],
-"kmlUrl": [],
-"technicalRating": [
-"3"
-],
-"waterRating": [
-"C1"
-],
-"riskRating": [],
-"permits": [
-"No"
-],
-"rappelCount": [
-"1r"
-],
-"rappelLongest": [
-{
-"value": 25,
-"unit": "ft"
-}
-],
-"months": [
-"Jun",
-"Jul",
-"Aug",
-"Sep",
-"Oct"
-],
-"shuttle": [],
-"vehicle": []
-},
-"fulltext": "Screw Auger Falls Gorge",
-"fullurl": "https://ropewiki.com/Screw_Auger_Falls_Gorge",
-"namespace": 0,
-"exists": true
-},
-"The Cataracts": {
-"printouts": {
-"pageid": [
-"68931"
-],
-"name": [
-"The Cataracts"
-],
-"coordinates": [
-{
-"lat": 44.6351,
-"lon": -70.8616
-}
-],
-"region": [
-{
-"fulltext": "Maine",
-"fullurl": "https://ropewiki.com/Maine",
-"namespace": 0,
-"exists": true
-}
-],
-"quality": [
-3
-],
-"rating": [
-" 3C II  (\u003Ci\u003Ev3a4\u0026nbsp;II\u003C/i\u003E)"
-],
-"timeRating": [
-"II"
-],
-"kmlUrl": [],
-"technicalRating": [
-"3"
-],
-"waterRating": [
-"C"
-],
-"riskRating": [],
-"permits": [
-"No"
-],
-"rappelCount": [
-"4-5r"
-],
-"rappelLongest": [
-{
-"value": 50,
-"unit": "ft"
-}
-],
-"months": [],
-"shuttle": [],
-"vehicle": []
-},
-"fulltext": "The Cataracts",
-"fullurl": "https://ropewiki.com/The_Cataracts",
-"namespace": 0,
-"exists": true
-}
-},
-"serializer": "SMW\\Serializers\\QueryResultSerializer",
-"version": 0.5,
-"rows": 5
+  "printrequests": [
+    {
+      "label": "",
+      "typeid": "_wpg",
+      "mode": 2,
+      "format": false
+    },
+    {
+      "label": "pageid",
+      "typeid": "_txt",
+      "mode": 1,
+      "format": ""
+    },
+    {
+      "label": "name",
+      "typeid": "_txt",
+      "mode": 1,
+      "format": ""
+    },
+    {
+      "label": "coordinates",
+      "typeid": "_geo",
+      "mode": 1,
+      "format": ""
+    },
+    {
+      "label": "region",
+      "typeid": "_wpg",
+      "mode": 1,
+      "format": ""
+    },
+    {
+      "label": "quality",
+      "typeid": "_num",
+      "mode": 1,
+      "format": ""
+    },
+    {
+      "label": "rating",
+      "typeid": "_txt",
+      "mode": 1,
+      "format": ""
+    },
+    {
+      "label": "timeRating",
+      "typeid": "_txt",
+      "mode": 1,
+      "format": ""
+    },
+    {
+      "label": "kmlUrl",
+      "typeid": "_txt",
+      "mode": 1,
+      "format": ""
+    },
+    {
+      "label": "technicalRating",
+      "typeid": "_txt",
+      "mode": 1,
+      "format": ""
+    },
+    {
+      "label": "waterRating",
+      "typeid": "_txt",
+      "mode": 1,
+      "format": ""
+    },
+    {
+      "label": "riskRating",
+      "typeid": "_txt",
+      "mode": 1,
+      "format": ""
+    },
+    {
+      "label": "permits",
+      "typeid": "_txt",
+      "mode": 1,
+      "format": ""
+    },
+    {
+      "label": "rappelCount",
+      "typeid": "_txt",
+      "mode": 1,
+      "format": ""
+    },
+    {
+      "label": "rappelLongest",
+      "typeid": "_qty",
+      "mode": 1,
+      "format": ""
+    },
+    {
+      "label": "months",
+      "typeid": "_txt",
+      "mode": 1,
+      "format": ""
+    },
+    {
+      "label": "shuttle",
+      "typeid": "_qty",
+      "mode": 1,
+      "format": ""
+    },
+    {
+      "label": "vehicle",
+      "typeid": "_txt",
+      "mode": 1,
+      "format": ""
+    }
+  ],
+  "results": {
+    "Bickford Slides Canyon": {
+      "printouts": {
+        "pageid": [
+          "68720"
+        ],
+        "name": [
+          "Bickford Slides Canyon"
+        ],
+        "coordinates": [
+          {
+            "lat": 44.274,
+            "lon": -70.9843
+          }
+        ],
+        "region": [
+          {
+            "fulltext": "Maine",
+            "fullurl": "https://ropewiki.com/Maine",
+            "namespace": 0,
+            "exists": true
+          }
+        ],
+        "quality": [
+          3
+        ],
+        "rating": [
+          " 3C II  (\\u003Ci\\u003Ev3a4\\u0026nbsp;II\\u003C/i\\u003E)"
+        ],
+        "timeRating": [
+          "II"
+        ],
+        "kmlUrl": [],
+        "technicalRating": [
+          "3"
+        ],
+        "waterRating": [
+          "C"
+        ],
+        "riskRating": [],
+        "permits": [
+          "No"
+        ],
+        "rappelCount": [
+          "3r"
+        ],
+        "rappelLongest": [
+          {
+            "value": 50,
+            "unit": "ft"
+          }
+        ],
+        "months": [
+          "Jun",
+          "Jul",
+          "Aug",
+          "Sep",
+          "Oct"
+        ],
+        "shuttle": [],
+        "vehicle": []
+      },
+      "fulltext": "Bickford Slides Canyon",
+      "fullurl": "https://ropewiki.com/Bickford_Slides_Canyon",
+      "namespace": 0,
+      "exists": true
+    },
+    "Inman's Cave": {
+      "printouts": {
+        "pageid": [
+          "68718"
+        ],
+        "name": [
+          "Inman's Cave"
+        ],
+        "coordinates": [
+          {
+            "lat": 44.2165,
+            "lon": -69.0747
+          }
+        ],
+        "region": [
+          {
+            "fulltext": "Maine",
+            "fullurl": "https://ropewiki.com/Maine",
+            "namespace": 0,
+            "exists": true
+          }
+        ],
+        "quality": [
+          0
+        ],
+        "rating": [
+          "Cave 3A I  (\\u003Ci\\u003Ev2a1\\u0026nbsp;I\\u003C/i\\u003E)"
+        ],
+        "timeRating": [
+          "I"
+        ],
+        "kmlUrl": [],
+        "technicalRating": [
+          "3"
+        ],
+        "waterRating": [
+          "A"
+        ],
+        "riskRating": [],
+        "permits": [
+          "No"
+        ],
+        "rappelCount": [
+          "2r"
+        ],
+        "rappelLongest": [
+          {
+            "value": 20,
+            "unit": "ft"
+          }
+        ],
+        "months": [],
+        "shuttle": [],
+        "vehicle": []
+      },
+      "fulltext": "Inman's Cave",
+      "fullurl": "https://ropewiki.com/Inman%27s_Cave",
+      "namespace": 0,
+      "exists": true
+    },
+    "Mount Katahdin": {
+      "printouts": {
+        "pageid": [
+          "25753"
+        ],
+        "name": [
+          "Mount Katahdin"
+        ],
+        "coordinates": [
+          {
+            "lat": 45.9043,
+            "lon": -68.922
+          }
+        ],
+        "region": [
+          {
+            "fulltext": "Maine",
+            "fullurl": "https://ropewiki.com/Maine",
+            "namespace": 0,
+            "exists": true
+          }
+        ],
+        "quality": [
+          5
+        ],
+        "rating": [
+          "POI"
+        ],
+        "timeRating": [],
+        "kmlUrl": [
+          "https://ropewiki.com/luca/rwr?gpx%3Doff\\u0026filename%3DMount_Katahdin\\u0026kmlnfx\\u0026kmlx%3Dhttp://brennen.caltech.edu/swhikes/katadn.htm\\u0026ext%3D.kml"
+        ],
+        "technicalRating": [],
+        "waterRating": [],
+        "riskRating": [],
+        "permits": [
+          "No"
+        ],
+        "rappelCount": [],
+        "rappelLongest": [],
+        "months": [],
+        "shuttle": [],
+        "vehicle": []
+      },
+      "fulltext": "Mount Katahdin",
+      "fullurl": "https://ropewiki.com/Mount_Katahdin",
+      "namespace": 0,
+      "exists": true
+    },
+    "Screw Auger Falls Gorge": {
+      "printouts": {
+        "pageid": [
+          "34280"
+        ],
+        "name": [
+          "Screw Auger Falls Gorge"
+        ],
+        "coordinates": [
+          {
+            "lat": 44.571944444444,
+            "lon": -70.91
+          }
+        ],
+        "region": [
+          {
+            "fulltext": "Maine",
+            "fullurl": "https://ropewiki.com/Maine",
+            "namespace": 0,
+            "exists": true
+          }
+        ],
+        "quality": [
+          0
+        ],
+        "rating": [
+          " 3C1 I  (\\u003Ci\\u003Ev2a4\\u0026nbsp;I\\u003C/i\\u003E)"
+        ],
+        "timeRating": [
+          "I"
+        ],
+        "kmlUrl": [],
+        "technicalRating": [
+          "3"
+        ],
+        "waterRating": [
+          "C1"
+        ],
+        "riskRating": [],
+        "permits": [
+          "No"
+        ],
+        "rappelCount": [
+          "1r"
+        ],
+        "rappelLongest": [
+          {
+            "value": 25,
+            "unit": "ft"
+          }
+        ],
+        "months": [
+          "Jun",
+          "Jul",
+          "Aug",
+          "Sep",
+          "Oct"
+        ],
+        "shuttle": [],
+        "vehicle": []
+      },
+      "fulltext": "Screw Auger Falls Gorge",
+      "fullurl": "https://ropewiki.com/Screw_Auger_Falls_Gorge",
+      "namespace": 0,
+      "exists": true
+    },
+    "The Cataracts": {
+      "printouts": {
+        "pageid": [
+          "68931"
+        ],
+        "name": [
+          "The Cataracts"
+        ],
+        "coordinates": [
+          {
+            "lat": 44.6351,
+            "lon": -70.8616
+          }
+        ],
+        "region": [
+          {
+            "fulltext": "Maine",
+            "fullurl": "https://ropewiki.com/Maine",
+            "namespace": 0,
+            "exists": true
+          }
+        ],
+        "quality": [
+          3
+        ],
+        "rating": [
+          " 3C II  (\\u003Ci\\u003Ev3a4\\u0026nbsp;II\\u003C/i\\u003E)"
+        ],
+        "timeRating": [
+          "II"
+        ],
+        "kmlUrl": [],
+        "technicalRating": [
+          "3"
+        ],
+        "waterRating": [
+          "C"
+        ],
+        "riskRating": [],
+        "permits": [
+          "No"
+        ],
+        "rappelCount": [
+          "4-5r"
+        ],
+        "rappelLongest": [
+          {
+            "value": 50,
+            "unit": "ft"
+          }
+        ],
+        "months": [],
+        "shuttle": [],
+        "vehicle": []
+      },
+      "fulltext": "The Cataracts",
+      "fullurl": "https://ropewiki.com/The_Cataracts",
+      "namespace": 0,
+      "exists": true
+    }
+  },
+  "serializer": "SMW\\Serializers\\QueryResultSerializer",
+  "version": 0.5,
+  "rows": 5
 }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -8,7 +8,8 @@ import {createPublicMapStyle} from './createPublicMapStyle';
 import {createPublicRoutes} from './createPublicRoutes';
 import {createPublicSchemas} from './createPublicSchemas';
 import {createPublicStats} from './createPublicStats';
-import {createPublicTiles} from './createPublicTiles';
+// ISSUE-102: Tippecanoe not working
+// import {createPublicTiles} from './createPublicTiles';
 import {scrapeRoutes} from './scrapeRoutes';
 import {syncStack} from './syncStack';
 import {SyncStackOutput} from './syncStack/getStackTemplate';
@@ -58,7 +59,8 @@ export async function main(argv: string[]) {
   await logger.step(createPublicSchemas, []);
   const routes = await logger.step(scrapeRoutes, [options.region, options.cachePath]);
   await logger.step(createPublicRoutes, [routes]);
-  await logger.step(createPublicTiles, []);
+  // ISSUE-102: Tippecanoe not working
+  // await logger.step(createPublicTiles, []);
   const stats = await logger.step(createPublicStats, []);
   logger.outputStats(stats, [options.region]);
   await logger.step(createPublicMapStyle, [stack?.URL ?? `http://localhost:3000`]);

--- a/src/cli/scrapeRoutes/parseDescription.ts
+++ b/src/cli/scrapeRoutes/parseDescription.ts
@@ -33,7 +33,7 @@ export async function parseDescription(input: string): Promise<string> {
         const htmlBody = input.slice(input.indexOf('==Introduction=='));
         pandoc(
           htmlBody,
-          '-f mediawiki -t markdown',
+          '-f mediawiki -t html',
           (error: Error, html: (string | boolean)) => {
             timeout.cancel();
             if (error) {

--- a/src/cli/scrapeRoutes/parseDescription.ts
+++ b/src/cli/scrapeRoutes/parseDescription.ts
@@ -2,6 +2,7 @@
 import pandoc from 'node-pandoc';
 import PromiseThrottle from 'promise-throttle';
 import {sleep} from '../../utils/sleep';
+import {logger} from '../../utils/logger';
 
 /**
  * Limit the number of Pandoc processes created to 500 per second to prevent the system from running
@@ -24,19 +25,29 @@ export async function parseDescription(input: string): Promise<string> {
 
     return await Promise.race([
       timeout.then(() => {
+        logger.error(`Pandoc timeout`)
         throw new PandocTimeoutError();
       }),
 
-      new Promise<string>((resolve, reject) =>
+      new Promise<string>((resolve, reject) => {
+        const htmlBody = input.slice(input.indexOf('==Introduction=='));
         pandoc(
-          input.slice(input.indexOf('==Introduction==')),
-          '-f mediawiki -t html',
-          (error: Error, html: string) => {
+          htmlBody,
+          '-f mediawiki -t markdown',
+          (error: Error, html: (string | boolean)) => {
             timeout.cancel();
-            if (error) reject(error);
-            else resolve(html);
+            if (error) {
+              reject(error);              
+            } else if (typeof html === 'string') {
+              resolve(html as string);
+            } else  {
+              const fallback = "Server error parsing description"
+              logger.error(`Unknown pandoc error -- non-string response. Patching with "${fallback}" and ignoring...`)
+              resolve(fallback);
+            }
           },
-        ),
+        )
+      },
       ),
     ]);
   });

--- a/src/cli/scrapeRoutes/parseRappelCount.ts
+++ b/src/cli/scrapeRoutes/parseRappelCount.ts
@@ -5,7 +5,7 @@ import {parseIntSafe} from '../../utils/parseIntSafe';
  */
 export default function parseRappelCount(input: string | undefined) {
   if (!input) return {rappelCountMin: undefined, rappelCountMax: undefined};
-  const match = input.match(/([0-9+])(-([0-9+]))?r/);
+  const match = input.match(/([0-9+]*)(-([0-9+]*))?r/);
   return {
     rappelCountMin: parseIntSafe(match?.[1]),
     rappelCountMax: parseIntSafe(match?.[3] ?? match?.[1]),

--- a/src/cli/scrapeRoutes/scrapeDescriptions.ts
+++ b/src/cli/scrapeRoutes/scrapeDescriptions.ts
@@ -23,6 +23,7 @@ export async function scrapeDescriptions(routes: RouteV2[], cachePath: string): 
       routeChunks.map(async routeChunk => {
         // See https://ropewiki.com/Export and https://www.mediawiki.org/wiki/API:Export for more
         // information about this API
+        // Example: http://ropewiki.com/api.php?format=json&action=query&export=true&pageids=68720
         const url = new URL('http://ropewiki.com/api.php');
         url.searchParams.append('format', 'json');
         url.searchParams.append('action', 'query');
@@ -73,13 +74,14 @@ export async function scrapeDescriptions(routes: RouteV2[], cachePath: string): 
                 if (isObject(error) && 'isPandocTimeoutError' in error) {
                   const result = text.slice(text.indexOf("Region"))
                   const region = result.split("|")[0].split("=")[1]
-                  logger.warn(`Pandoc timed out for "${index.name}", re-run region ${region} to debug.`);
-                  logger.log(`If running the region alone succeeds, consider lowering requestsPerSecond in parseDescription before re-running suite`)
+                  logger.warn(`Pandoc timed out for "${index.name}", re-run region "${region}" to debug.`);
+                  logger.log(`If running the region alone succeeds, consider adjusting requestsPerSecond or timeoutMilliseconds in parseDescription`)
+                  logger.log(`If running the region alone fails, it must be a pandoc issue`)
                   return undefined;
                 } else {
                   throw error;
                 }
-              }),
+              })
             };
 
             logger.progress(totalCount, ++doneCount, index.name);

--- a/src/cli/scrapeRoutes/scrapeDescriptions.ts
+++ b/src/cli/scrapeRoutes/scrapeDescriptions.ts
@@ -5,6 +5,8 @@ import {validate} from '../../utils/getValidator';
 import {logger} from '../../utils/logger';
 import cachedFetch from './cachedFetch';
 import {parseDescription} from './parseDescription';
+import {md5} from './cachedFetch';
+import Path from 'path';
 
 /**
  * Take an array of `RouteV2`s, scrape their KMLs, and return a new array of routes with the
@@ -28,27 +30,51 @@ export async function scrapeDescriptions(routes: RouteV2[], cachePath: string): 
         url.searchParams.append('pageids', routeChunk.map(index => index.id).join('|'));
 
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const xml: any = await new Promise(async (resolve, reject) =>
+        const xml: any = await new Promise(async (resolve, reject) => {
+          let jsonResponse = await cachedFetch(url, 'utf-8', cachePath);
+          if (typeof jsonResponse !== 'string') {
+            logger.error(`Cached response is not string, its ${typeof jsonResponse}: \n${jsonResponse}`);
+            resolve(undefined)
+            return
+          }
+          if (jsonResponse.length < 1) {
+            logger.error(`Fetch response was empty for: ${url}`);
+            const path = Path.join(cachePath, `${md5(url.toString())}.txt`);
+            logger.log(`Please repair file at ${path} manually and re-run`)
+            resolve(undefined)
+            return            
+          }
+
+          const parsed = JSON.parse(jsonResponse).query.export['*'];
           XML2JS.parseString(
-            JSON.parse(await cachedFetch(url, 'utf-8', cachePath)).query.export['*'],
+            parsed,
             (error, result) => {
               if (error) reject(error);
               else resolve(result);
             },
-          ),
+          )
+        }
+
         );
 
         return await Promise.all(
           routeChunk.map(async index => {
+            if (!xml) {
+              return xml
+            }
+
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            const text = xml.mediawiki.page.find((page: any) => page.id[0] === String(index.id))
-              .revision[0].text[0]._;
+            const page = xml.mediawiki.page.find((page: any) => page.id[0] === String(index.id))
+            const text = page.revision[0].text[0]._;
 
             const route: RouteV2 = {
               ...index,
               description: await parseDescription(text).catch(error => {
                 if (isObject(error) && 'isPandocTimeoutError' in error) {
-                  logger.warn(`Pandoc timed out for "${index.name}"`);
+                  const result = text.slice(text.indexOf("Region"))
+                  const region = result.split("|")[0].split("=")[1]
+                  logger.warn(`Pandoc timed out for "${index.name}", re-run region ${region} to debug.`);
+                  logger.log(`If running the region alone succeeds, consider lowering requestsPerSecond in parseDescription before re-running suite`)
                   return undefined;
                 } else {
                   throw error;

--- a/src/types/v2.ts
+++ b/src/types/v2.ts
@@ -45,7 +45,6 @@ export interface IndexRouteV2 {
  */
 export interface RouteV2 extends IndexRouteV2 {
   url: string;
-  // markdown
   description: string | undefined;
   geojson: FeatureCollection | undefined;
 }

--- a/src/types/v2.ts
+++ b/src/types/v2.ts
@@ -45,6 +45,7 @@ export interface IndexRouteV2 {
  */
 export interface RouteV2 extends IndexRouteV2 {
   url: string;
+  // markdown
   description: string | undefined;
   geojson: FeatureCollection | undefined;
 }


### PR DESCRIPTION
The main goal of this PR is to update the index information because rappel numbers had a serious issue where "18->22" would be read as "2" instead of "18" and "22" so all rappel numbers were truncated and the range was not being read if more than two digits were involved.

Along the way, a number of challenges were encountered:
* Unclear that dependencies needed to be install outside of yarn when they are also required in yarn (updated README)
* Pandoc fails due to unknown reasons with a unexpressed type response (boolean, not string) which halts execution [ISSUE-32]
* Could not get tinnecanoe to succeed [ISSUE-102]
* Socket is always terminating when trying to pull KMLs from New Mexico [ISSUE-104]
* Issues with cached files being read 

Note: Because of the tippecannoe issues test execution currently always fails and tile creation has been disabled in this PR